### PR TITLE
fix(deps): allow ovos-workshop 9.x (widen <9.0.0 -> <10.0.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ovos-utils>=0.0.38
-ovos-workshop>=0.0.15,<9.0.0
+ovos-workshop>=0.0.15,<10.0.0


### PR DESCRIPTION
ovos-workshop is on the 9.x line. This `<9.0.0` cap is one of the last in core's `skills-essential` extra blocking `ovos-core` from resolving its modern `ovos-workshop>=9.x` floor (PIPELINE-1 / handler-lifecycle work). Widen to `<10.0.0`, matching the rest of the skill ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)