### PR TITLE
test: add ovoscope end2end intent-routing tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'ovos_skill_personal'
       test_path: 'test/'
-      install_extras: 'test'
+      install_extras: '.[test]'
       min_coverage: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'ovos_skill_personal'
       test_path: 'test/'
-      install_extras: ''
+      install_extras: 'test'
       min_coverage: 0

--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -12,4 +12,7 @@ jobs:
     with:
       python_version: '3.11'
       install_extras: 'test'
+      require_adapt: true
+      require_padatious: true
+      system_deps: 'swig libfann-dev'
       test_path: 'test/end2end/'

--- a/setup.py
+++ b/setup.py
@@ -76,5 +76,13 @@ setup(
     include_package_data=True,
     install_requires=required("requirements.txt"),
     keywords='ovos skill plugin',
+    extras_require={
+        'test': [
+            'pytest',
+            'pytest-timeout',
+            'ovoscope>=1.0.1a1',
+            'ovos-adapt-parser>=1.0.9,<2.0.0',
+        ],
+    },
     entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
 )

--- a/test/end2end/test_intents_en_us.py
+++ b/test/end2end/test_intents_en_us.py
@@ -1,0 +1,68 @@
+"""End-to-end intent routing tests for the en-US locale.
+
+Each canonical utterance is fired through a real MiniCroft and asserted to
+route to the expected intent handler and produce a spoken response. The reply
+text depends on runtime configuration, so assertions cover the intent binding
+and the presence of a ``speak`` response, not the dialog content.
+"""
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovoscope import CaptureSession, get_minicroft
+
+SKILL_ID = "ovos-skill-personal.openvoiceos"
+
+
+class TestPersonalIntentsEnUS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.minicroft = get_minicroft([SKILL_ID])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.minicroft.stop()
+
+    def _run(self, text):
+        session = Session("test-session")
+        session.pipeline = [
+            "ovos-adapt-pipeline-plugin-high",
+            "ovos-padatious-pipeline-plugin-high",
+            "ovos-padacioso-pipeline-plugin-high",
+            "ovos-adapt-pipeline-plugin-medium",
+            "ovos-padacioso-pipeline-plugin-medium",
+            "ovos-adapt-pipeline-plugin-low",
+        ]
+        utterance = Message(
+            "recognizer_loop:utterance",
+            {"utterances": [text], "lang": "en-US"},
+            {"session": session.serialize(), "source": "A", "destination": "B"},
+        )
+        capture = CaptureSession(self.minicroft)
+        capture.capture(utterance, timeout=30)
+        return capture.finish()
+
+    def _assert_intent(self, text, intent):
+        messages = self._run(text)
+        types = [m.msg_type for m in messages]
+        self.assertIn(f"{SKILL_ID}:{intent}", types)
+        self.assertTrue(any("speak" in t for t in types))
+
+    def test_who_are_you(self):
+        self._assert_intent("tell me about yourself", "WhoAreYou.intent")
+
+    def test_what_are_you(self):
+        self._assert_intent("describe what you are", "WhatAreYou.intent")
+
+    def test_who_made_you(self):
+        self._assert_intent("by whom were you created", "WhoMadeYou.intent")
+
+    def test_when_were_you_born(self):
+        self._assert_intent("what is your date of birth", "WhenWereYouBorn.intent")
+
+    def test_where_were_you_born(self):
+        self._assert_intent("where do you come from", "WhereWereYouBorn.intent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_adapt_intents_de.py
+++ b/test/unittests/test_adapt_intents_de.py
@@ -4,8 +4,8 @@ from os.path import join, dirname
 import os
 from ovos_utils.bracket_expansion import expand_options
 
-from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.intent import IntentBuilder
 
 
 def collect_intents(skill_file):

--- a/test/unittests/test_adapt_intents_en.py
+++ b/test/unittests/test_adapt_intents_en.py
@@ -4,8 +4,8 @@ from os.path import join, dirname
 import os
 from ovos_utils.bracket_expansion import expand_parentheses, expand_options
 
-from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.intent import IntentBuilder
 
 
 def collect_intents(skill_file):

--- a/test/unittests/test_adapt_intents_es.py
+++ b/test/unittests/test_adapt_intents_es.py
@@ -4,8 +4,8 @@ from os.path import join, dirname
 import os
 from ovos_utils.bracket_expansion import expand_parentheses, expand_options
 
-from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.intent import IntentBuilder
 
 
 def collect_intents(skill_file):

--- a/test/unittests/test_adapt_intents_fr.py
+++ b/test/unittests/test_adapt_intents_fr.py
@@ -4,8 +4,8 @@ from os.path import join, dirname
 import os
 from ovos_utils.bracket_expansion import expand_parentheses, expand_options
 
-from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.intent import IntentBuilder
 
 
 def collect_intents(skill_file):

--- a/test/unittests/test_adapt_intents_it.py
+++ b/test/unittests/test_adapt_intents_it.py
@@ -4,8 +4,8 @@ from os.path import join, dirname
 import os
 from ovos_utils.bracket_expansion import expand_parentheses, expand_options
 
-from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.intent import IntentBuilder
 
 
 def collect_intents(skill_file):

--- a/test/unittests/test_adapt_intents_pt.py
+++ b/test/unittests/test_adapt_intents_pt.py
@@ -4,8 +4,8 @@ from os.path import join, dirname
 import os
 from ovos_utils.bracket_expansion import expand_parentheses, expand_options
 
-from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
+from ovos_adapt.engine import IntentDeterminationEngine
+from ovos_adapt.intent import IntentBuilder
 
 
 def collect_intents(skill_file):

--- a/test/unittests/test_skill_loading.py
+++ b/test/unittests/test_skill_loading.py
@@ -4,12 +4,10 @@ from os.path import join, dirname
 import os
 from ovos_utils.bracket_expansion import expand_parentheses, expand_options
 
-from adapt.engine import IntentDeterminationEngine
-from adapt.intent import IntentBuilder
 from ovos_skill_personal import PersonalSkill
 from ovos_plugin_manager.skills import find_skill_plugins
-from ovos_utils.messagebus import FakeBus
-from mycroft.skills.skill_loader import PluginSkillLoader, SkillLoader
+from ovos_utils.fakebus import FakeBus
+from ovos_workshop.skill_launcher import PluginSkillLoader
 
 
 class TestSkillLoading(unittest.TestCase):


### PR DESCRIPTION
Adds drift-proof ovoscope end-to-end intent-routing coverage for the en-US locale, restoring the e2e suite for this skill.

- `test/end2end/test_intents_en_us.py`: fires each canonical utterance through a real MiniCroft (CaptureSession) and asserts the intent binds and a spoken response is produced, covering WhoAreYou, WhatAreYou, WhoMadeYou, WhenWereYouBorn and WhereWereYouBorn.
- `.github/workflows/ovoscope.yml`: enable require_adapt + require_padatious and the swig/libfann system deps.
- `setup.py`: expose the `test` extra (ovoscope, ovos-adapt-parser, pytest, pytest-timeout).

Follows the same CaptureSession subset-assertion pattern adopted across the sibling skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated test installation option with the tools needed for automated testing.
  - Expanded end-to-end coverage for English personal-intent voice interactions.

- **Tests**
  - Improved workflow support for required components and system dependencies.
  - Updated intent and skill-loading tests to use current package interfaces across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->