### PR TITLE
fix: rename entry-point group to opm.skill

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,5 +84,5 @@ setup(
             'ovos-adapt-parser>=1.0.9,<2.0.0',
         ],
     },
-    entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
+    entry_points={'opm.skill': PLUGIN_ENTRY_POINT}
 )


### PR DESCRIPTION
Rename the packaging entry-point group from the deprecated ovos.plugin.skill to opm.skill. OPM still loads the skill under the old group but logs a deprecation warning on every boot; this silences it. The entry-point value is unchanged and still points at the SkillClass.